### PR TITLE
[GWS-3793] make security arg optional for csharp client

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -10,6 +10,7 @@ sources:
             - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
               authHeader: Authorization
               authSecret: $openapi_doc_auth_token
+            - location: gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
         registry:
             location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas
 targets:

--- a/gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
+++ b/gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
@@ -1,0 +1,13 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Speakeasy Modifications
+  version: 0.0.2
+  x-speakeasy-metadata:
+    after: ""
+    before: ""
+    type: speakeasy-modifications
+actions:
+  - target: $.paths..security
+    update:
+      - {}


### PR DESCRIPTION
https://gustohq.atlassian.net/browse/GWS-3793

Makes the `security` requirement [optional](https://www.speakeasy.com/openapi/security#optional-security) for C#. Introduces a new `gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml` overlay to handle this modification.

running `git diff gusto_embedded/src/GustoEmbedded/Models/Requests/GetV1WebhookSubscriptionsSecurity.cs` after generating a new client with the overlays using `speakeasy run`:
![Screenshot 2025-02-25 at 4 15 58 PM](https://github.com/user-attachments/assets/159bf073-c163-4a85-b9f3-a377126c1876)
