### PR TITLE
Adds gusto-ubuntu-default runner to Speakeasy actions #49

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -19,11 +19,12 @@ permissions:
     - cron: 0 0 * * *
 jobs:
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+    uses: Gusto/sdk-generation-action/.github/workflows/workflow-executor.yaml@main
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr
       set_version: ${{ github.event.inputs.set_version }}
+      runs-on: "{\"group\": \"gusto-ubuntu-default\"}"
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -14,9 +14,10 @@ permissions:
   workflow_dispatch: {}
 jobs:
   publish:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    uses: Gusto/sdk-generation-action/.github/workflows/workflow-executor.yaml@main
     with:
       target: gusto
+      runs-on: "{\"group\": \"gusto-ubuntu-default\"}"
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
Puts us in compliance with Gusto's new security policy by adding 
```
runs-on: "{\"group\": \"gusto-ubuntu-default\"}"
```
to all speakeasy github actions.

This PR also swaps out the reusable workflow we're using to a fork of Speakeasy's action. Github has a [limitation on this type of action](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-self-hosted-runners) where we cannot queue self-hosted runners across organizations.