### PR TITLE
chore: bump API version to v2025-11-15

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,29 +1,55 @@
+---
 workflowVersion: 1.0.0
 speakeasyVersion: latest
 sources:
-    Gusto-OAS:
-        inputs:
-            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-06-15.embedded.yaml
-              authHeader: Authorization
-              authSecret: $openapi_doc_auth_token
-        overlays:
-            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
-              authHeader: Authorization
-              authSecret: $openapi_doc_auth_token
-            - location: gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
-        registry:
-            location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas
+  Gusto-OAS:
+    inputs:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-11-15.embedded.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    overlays:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    - location: gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
+    registry:
+      location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas
+  Gusto-OAS-v2025-06-15:
+    inputs:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-06-15.embedded.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    overlays:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    - location: gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
+    registry:
+      location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas
 targets:
-    gusto:
-        target: csharp
-        source: Gusto-OAS
-        output: ./gusto_embedded
-        publish:
-            nuget:
-                apiKey: $nuget_api_key
-        codeSamples:
-            registry:
-                location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas-csharp-code-samples
-            labelOverride:
-                fixedValue: Csharp (SDK)
-            blocking: false
+  gusto:
+    target: csharp
+    source: Gusto-OAS
+    output: "./gusto_embedded"
+    publish:
+      nuget:
+        apiKey: "$nuget_api_key"
+    codeSamples:
+      registry:
+        location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas-csharp-code-samples
+      labelOverride:
+        fixedValue: Csharp (SDK)
+      blocking: false
+  gusto-v2025-06-15:
+    target: csharp
+    source: Gusto-OAS-v2025-06-15
+    output: "./gusto_embedded_v_2025_06_15"
+    publish:
+      nuget:
+        apiKey: "$nuget_api_key"
+    codeSamples:
+      registry:
+        location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas-csharp-code-samples
+      labelOverride:
+        fixedValue: Csharp (SDK)
+      blocking: false


### PR DESCRIPTION
## Summary
- Updates workflow.yaml to use API version `v2025-11-15`
- Preserves previous version SDK in versioned directories (e.g., `gusto_embedded_v_YYYY_MM_DD`)
- Adds versioned source and target entries to workflow.yaml for backwards compatibility

## Notes
Merge the Gusto-Partner-API PR first before merging this PR.