### PR TITLE
chore: bump API version to v2025-11-15

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,29 +1,55 @@
+---
 workflowVersion: 1.0.0
 speakeasyVersion: latest
 sources:
-    Gusto-OAS:
-        inputs:
-            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-06-15.embedded.yaml
-              authHeader: Authorization
-              authSecret: $openapi_doc_auth_token
-        overlays:
-            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
-              authHeader: Authorization
-              authSecret: $openapi_doc_auth_token
-            - location: gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
-        registry:
-            location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas
+  Gusto-OAS:
+    inputs:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-06-15.embedded.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    overlays:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    - location: gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
+    registry:
+      location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas
+  Gusto-OAS-v2025-11-15:
+    inputs:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-11-15.embedded.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    overlays:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    - location: gusto_embedded_v_2025_11_15/.speakeasy/speakeasy-modifications-overlay.yaml
+    registry:
+      location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas-v2025-11-15
 targets:
-    gusto:
-        target: csharp
-        source: Gusto-OAS
-        output: ./gusto_embedded
-        publish:
-            nuget:
-                apiKey: $nuget_api_key
-        codeSamples:
-            registry:
-                location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas-csharp-code-samples
-            labelOverride:
-                fixedValue: Csharp (SDK)
-            blocking: false
+  gusto:
+    target: csharp
+    source: Gusto-OAS
+    output: "./gusto_embedded"
+    publish:
+      nuget:
+        apiKey: "$nuget_api_key"
+    codeSamples:
+      registry:
+        location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas-csharp-code-samples
+      labelOverride:
+        fixedValue: Csharp (SDK)
+      blocking: false
+  gusto-v2025-11-15:
+    target: csharp
+    source: Gusto-OAS-v2025-11-15
+    output: "./gusto_embedded_v_2025_11_15"
+    publish:
+      nuget:
+        apiKey: "$nuget_api_key"
+    codeSamples:
+      registry:
+        location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-oas-csharp-code-samples-v2025-11-15
+      labelOverride:
+        fixedValue: Csharp (SDK)
+      blocking: false

--- a/gusto_embedded_v_2025_11_15/.speakeasy/gen.yaml
+++ b/gusto_embedded_v_2025_11_15/.speakeasy/gen.yaml
@@ -1,0 +1,45 @@
+---
+configVersion: 2.0.0
+generation:
+  sdkClassName: Gusto
+  maintainOpenAPIOrder: true
+  usageSnippets:
+    optionalPropertyRendering: withExample
+  useClassNamesForArrayFields: true
+  fixes:
+    nameResolutionDec2023: true
+    nameResolutionFeb2025: false
+    parameterOrderingFeb2024: true
+    requestResponseComponentNamesFeb2024: true
+    securityFeb2025: false
+  auth:
+    oAuth2ClientCredentialsEnabled: true
+    oAuth2PasswordEnabled: true
+csharp:
+  version: 0.0.1
+  additionalDependencies: []
+  author: Speakeasy
+  clientServerStatusCodesAsErrors: true
+  defaultErrorName: APIException
+  disableNamespacePascalCasingApr2024: true
+  dotnetVersion: net8.0
+  enableSourceLink: false
+  flattenGlobalSecurity: true
+  flatteningOrder: parameters-first
+  imports:
+    option: openapi
+    paths:
+      callbacks: Models/Callbacks
+      errors: Models/Errors
+      operations: Models/Requests
+      shared: Models/Components
+      webhooks: Models/Webhooks
+  includeDebugSymbols: false
+  inputModelSuffix: input
+  maxMethodParams: 4
+  methodArguments: infer-optional-args
+  outputModelSuffix: output
+  packageName: GustoEmbedded.V2025_11_15
+  packageTags: ''
+  responseFormat: envelope-http
+  sourceDirectory: src

--- a/gusto_embedded_v_2025_11_15/.speakeasy/speakeasy-modifications-overlay.yaml
+++ b/gusto_embedded_v_2025_11_15/.speakeasy/speakeasy-modifications-overlay.yaml
@@ -1,0 +1,13 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Speakeasy Modifications
+  version: 0.0.2
+  x-speakeasy-metadata:
+    after: ""
+    before: ""
+    type: speakeasy-modifications
+actions:
+  - target: $.paths..security
+    update:
+      - {}


### PR DESCRIPTION
## Summary
- Adds versioned SDK directory and workflow entries for API version `v2025-11-15`
- Existing entries are frozen at their current version for backwards compatibility

## Notes
**Dependency: merge #27 first.** That PR untracks `.speakeasy/workflow.local.yaml`; this PR has been rebased to assume the file is already gone.

Merge order:
1. Gusto-Partner-API: `fix: harden codegen --new-version scaffold` (script hardening)
2. gusto-csharp-client #27: `chore: untrack .speakeasy/workflow.local.yaml`
3. This PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)